### PR TITLE
Fix duplicate error logging

### DIFF
--- a/worker_common.go
+++ b/worker_common.go
@@ -109,7 +109,6 @@ func (w *CommonWorker) Perform(job *Job, opt ...Option) error {
 			err := RunE(func() error { return h(job) }, WithJob(job))
 			syncCancel() // no reason to defer this
 			if err != nil {
-				w.Logger.Error(err)
 				return err
 			}
 			return nil


### PR DESCRIPTION
This fix addresses Issue #1, that errors returned from handlers are logged twice (via `PerformX`, and by `Perform`). There is no call to `Perform` that does not also log the error returned by `Perform`, so I think it's safe to delete.