### PR TITLE
Change all BoseCorp/go-work references to Bose/go-work

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If we do have concurrent work, then we also need to manage things like:
 
 # Using go-work
 
-## [Jobs](https://github.com/BoseCorp/go-work/blob/master/docs.md#type-job)
+## [Jobs](https://github.com/Bose/go-work/blob/master/docs.md#type-job)
 Jobs define the work to be done in a common interface.  Think of them like an http.Request with an attached context (Ctx).   Jobs have Args, Context, and optional timeouts.   A Job.Ctx has key/values which can be used to pass data down the chain of adapters (aka middleware).  A Job.Ctx.Status is set by a Handler to represent the state of the Job's execution: Success, Error, NoResponse, etc)  Jobs are passed to Handlers by a Worker for each request.   
 ``` go
 type Job struct {
@@ -44,7 +44,7 @@ type Job struct {
 }
 
 ```
-## [Handlers](https://github.com/BoseCorp/go-work/blob/master/docs.md#type-handler)
+## [Handlers](https://github.com/Bose/go-work/blob/master/docs.md#type-handler)
 Handlers define the func to be executed for a Job by a Worker.  Handlers also represent an interface than can be chained together to create middleware (aka Adapters)
 ``` go
 type Handler func(j *Job) error
@@ -101,7 +101,7 @@ func DefaultPublishNextMessageCRDB(j *work.Job) error {
 }
 ```
 
-## [Concurrent Job](https://github.com/BoseCorp/go-work/blob/master/docs.md#type-concurrentjob)
+## [Concurrent Job](https://github.com/Bose/go-work/blob/master/docs.md#type-concurrentjob)
 Concurrent jobs define a job to be performed by workers concurrently.
 
 ``` go
@@ -183,7 +183,7 @@ const (
 )
 ```
 
-## [Worker](https://github.com/BoseCorp/go-work/blob/master/docs.md#type-worker)
+## [Worker](https://github.com/Bose/go-work/blob/master/docs.md#type-worker)
 A Worker implements an interface that defines how a Job will be executed.  
 - now (sync and async)
 - at a time in the future (only async)
@@ -196,7 +196,7 @@ defer w.Stop()
 ```
 
 Official implementations:  
-- [CommonWorker](https://github.com/BoseCorp/go-work/blob/master/docs.md#type-worker). CommonWorkers is backed by the standard lib and goroutines. 
+- [CommonWorker](https://github.com/Bose/go-work/blob/master/docs.md#type-worker). CommonWorkers is backed by the standard lib and goroutines. 
 
 ``` go
 type Worker interface {
@@ -262,4 +262,4 @@ I need to acknowledge that many of the ideas implemented in this library are not
 - Mark Bate's Buffalo [Worker](https://gobuffalo.io/en/docs/workers)
 
 ---
-##  Complete API reference: [docs.md](https://github.com/BoseCorp/go-work/blob/master/docs.md#type-commonworker)
+##  Complete API reference: [docs.md](https://github.com/Bose/go-work/blob/master/docs.md#type-commonworker)

--- a/docs.md
+++ b/docs.md
@@ -1,7 +1,7 @@
 
 
 # work
-`import "github.com/BoseCorp/go-work"`
+`import "github.com/Bose/go-work"`
 
 * [Overview](#pkg-overview)
 * [Index](#pkg-index)
@@ -100,7 +100,7 @@
 
 
 #### <a name="pkg-files">Package files</a>
-[channel.go](/src/github.com/BoseCorp/go-work/channel.go) [concurrent_job.go](/src/github.com/BoseCorp/go-work/concurrent_job.go) [context.go](/src/github.com/BoseCorp/go-work/context.go) [job.go](/src/github.com/BoseCorp/go-work/job.go) [logger.go](/src/github.com/BoseCorp/go-work/logger.go) [metrics.go](/src/github.com/BoseCorp/go-work/metrics.go) [middleware.go](/src/github.com/BoseCorp/go-work/middleware.go) [middleware_aggregatelogger.go](/src/github.com/BoseCorp/go-work/middleware_aggregatelogger.go) [middleware_health.go](/src/github.com/BoseCorp/go-work/middleware_health.go) [middleware_opentracing.go](/src/github.com/BoseCorp/go-work/middleware_opentracing.go) [middleware_prometheus.go](/src/github.com/BoseCorp/go-work/middleware_prometheus.go) [options.go](/src/github.com/BoseCorp/go-work/options.go) [safe.go](/src/github.com/BoseCorp/go-work/safe.go) [session.go](/src/github.com/BoseCorp/go-work/session.go) [span.go](/src/github.com/BoseCorp/go-work/span.go) [status.go](/src/github.com/BoseCorp/go-work/status.go) [worker.go](/src/github.com/BoseCorp/go-work/worker.go) [worker_common.go](/src/github.com/BoseCorp/go-work/worker_common.go) 
+[channel.go](/src/github.com/Bose/go-work/channel.go) [concurrent_job.go](/src/github.com/Bose/go-work/concurrent_job.go) [context.go](/src/github.com/Bose/go-work/context.go) [job.go](/src/github.com/Bose/go-work/job.go) [logger.go](/src/github.com/Bose/go-work/logger.go) [metrics.go](/src/github.com/Bose/go-work/metrics.go) [middleware.go](/src/github.com/Bose/go-work/middleware.go) [middleware_aggregatelogger.go](/src/github.com/Bose/go-work/middleware_aggregatelogger.go) [middleware_health.go](/src/github.com/Bose/go-work/middleware_health.go) [middleware_opentracing.go](/src/github.com/Bose/go-work/middleware_opentracing.go) [middleware_prometheus.go](/src/github.com/Bose/go-work/middleware_prometheus.go) [options.go](/src/github.com/Bose/go-work/options.go) [safe.go](/src/github.com/Bose/go-work/safe.go) [session.go](/src/github.com/Bose/go-work/session.go) [span.go](/src/github.com/Bose/go-work/span.go) [status.go](/src/github.com/Bose/go-work/status.go) [worker.go](/src/github.com/Bose/go-work/worker.go) [worker_common.go](/src/github.com/Bose/go-work/worker_common.go) 
 
 
 ## <a name="pkg-constants">Constants</a>

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/BoseCorp/go-work
+module github.com/Bose/go-work
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae h1:xiXzMMEQdQcric9hXtr1QU98MHunKK7OTtsoU6bYWs4=
 golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
This PR updates the `go.mod` to properly define the module for the current remote repository, `github.com/Bose/go-work` (as opposed to `BoseCorp/go-work`). This was causing `go get` failures:

```bash
$ go get github.com/Bose/go-work
go: finding github.com/Bose/go-work latest
go get: github.com/Bose/go-work@v0.0.0-20200210124521-134e38d85794: parsing go.mod:
        module declares its path as: github.com/BoseCorp/go-work
                but was required as: github.com/Bose/go-work
```

It also updates documentation links.