### PR TITLE
Expose configuration options for logLevel, silencing successful jobs …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Bose/go-work
 go 1.12
 
 require (
-	github.com/Bose/go-gin-logrus v0.0.0-20190521185403-e97d8b4f57c6
+	github.com/Bose/go-gin-logrus/v2 v2.0.12
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.4.0
 	github.com/google/uuid v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Bose/go-gin-logrus v0.0.0-20190521185403-e97d8b4f57c6 h1:XwCTMk1uut6fOs1KCjouRNdVr3e1uFDhLcmnrLwyC4c=
-github.com/Bose/go-gin-logrus v0.0.0-20190521185403-e97d8b4f57c6/go.mod h1:GZUsPDxJLq+eLLLzorO4Qxgm+HjuvHNQTxIJM4vIy3Q=
+github.com/Bose/go-gin-logrus/v2 v2.0.12 h1:bLPAdhCfujd8+et2XEjiXxStxY8LTvq7L/nVjmbWUNY=
+github.com/Bose/go-gin-logrus/v2 v2.0.12/go.mod h1:B2vUlSZ+lYPW8k/CIjC0Zg1b/qc34kHtKkWD20iDtIs=
 github.com/Bose/go-gin-opentracing v1.0.3/go.mod h1:MRjPy7yY92/G4L9B1b1YGSIuSGpevD20ew0g4pMOiZk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/status.go
+++ b/status.go
@@ -7,7 +7,7 @@ const (
 	// StatusUnknown was a job with an unknown status
 	StatusUnknown Status = -1
 
-	// StatusSucces was a successful job
+	// StatusSuccess was a successful job
 	StatusSuccess = 200
 
 	// StatusBadRequest was a job with a bad request


### PR DESCRIPTION
Expose configuration options for logLevel, silencing successful jobs logs, and a custom reduced logging function.

`WithSilentSuccess(silent bool)` - Will not print any log messages if the job was successful, similar to the existing `WithSilentNoResponse`
`WithReducedLoggingFunc(a ReducedLoggingFunc)` - Allows passing a function to determine which logs to print
`WithLogLevel(level logrus.Level)` - Set the log level, which defaulted to Debug.

These are all optional configurations, and functionality stays as it currently is if they are not changed.